### PR TITLE
Allow rules to have a value

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ rules!(tokens => {
 
 ## Using proc-macro-rules
 
-Add `proc-macro-rules = "0.1.1"` to your Cargo.toml. You'll need the following feature flags:
+Add `proc-macro-rules = "0.1.1"` to your Cargo.toml. You'll need the following feature flag:
 
 ```rust
 #![feature(proc_macro_hygiene)]
-#![feature(label_break_value)]
 ```
 
 Import the `rules` macro with `use proc_macro_rules::rules`, then use with `rules!(tokens => { branches });` where `tokens` is an expression which evaluates to a `TokenStream` (such as the argument in the definition of a procedural macro).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@
 
 
 #![feature(proc_macro_hygiene)]
-#![feature(label_break_value)]
 
 extern crate proc_macro2;
 extern crate proc_macro_rules_macros as macros;


### PR DESCRIPTION
Fixes #19 -- Allow \`rules!\` to have a value
Fixes #20 -- Stop suppressing unreachable_code warning in #body
Fixes #21 -- Remove label_break_value requirement

#### Before:

```rust
#[allow(unreachable_code)]
'outer: {
    let tts = &#clause;
    {
        ...
        match syn::parse2(tts.clone()) {
            Ok(Matches { #(#vars,)* }) => {
                #body;
                break 'outer;
            }
            Err(e) => {}
        }
    }
    panic!("No rules matched input");
}
```

#### After:

```rust
{
    let tts = &#clause;
    if let Some(value) = {
        ...
        match syn::parse2(tts.clone()) {
            Ok(Matches { #(#vars,)* }) => {
                let value = { #body };
                #[allow(unreachable_code)]
                {
                    Some(value)
                }
            }
            Err(e) => None,
        }
    } {
        value
    }
    ...
    else {
        panic!("No rules matched input");
    }
}
```