### PR TITLE
Update dependencies and fix unsafety in next_builder_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/target-ra
 **/*.rs.bk
 Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
-/target-ra
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ readme = "README.md"
 license = "Apache-2.0/MIT"
 
 [dependencies]
-proc-macro-hack = "0.5.20"
-proc-macro-rules-macros = { path = "macros" }
+proc-macro-rules-macros = "0.2.0"
 proc-macro2 = "1.0.56"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro-rules"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 repository = "https://github.com/nrc/proc-macro-rules"
@@ -10,12 +10,11 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 proc-macro-rules-macros = "0.2.0"
-proc-macro2 = "0.4.21"
-proc-macro-hack = "0.5"
-syn = { version = "0.15.0", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0.56"
+syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-quote = "0.6"
+quote = "1.0.26"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "Apache-2.0/MIT"
 
 [dependencies]
-proc-macro-rules-macros = "0.2.0"
+proc-macro-rules-macros = { path = "macros" }
 proc-macro2 = "1.0.56"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ readme = "README.md"
 license = "Apache-2.0/MIT"
 
 [dependencies]
-proc-macro-rules-macros = "0.2.0"
+proc-macro-hack = "0.5.20"
+proc-macro-rules-macros = { path = "macros" }
 proc-macro2 = "1.0.56"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ rules!(tokens => {
 
 ## Using proc-macro-rules
 
-Add `proc-macro-rules = "0.2.1"` to your Cargo.toml.
+Add `proc-macro-rules = "0.3.0"` (or `proc-macro-rules = "0.2.1"` for versions between 1.31 and 1.56) to your Cargo.toml.
 
 Import the `rules` macro with `use proc_macro_rules::rules`, then use with `rules!(tokens => { branches });` where `tokens` is an expression which evaluates to a `TokenStream` (such as the argument in the definition of a procedural macro).
 

--- a/examples/macro_rules.rs
+++ b/examples/macro_rules.rs
@@ -15,7 +15,7 @@ use proc_macro_rules::rules;
 use quote::quote;
 
 // Declarative version using macro_rules.
-macro_rules! vec_rules {
+macro_rules! vec {
     () => {
         Vec::new()
     };
@@ -32,7 +32,7 @@ macro_rules! vec_rules {
 
 // Procedural version.
 #[proc_macro]
-pub fn vec_proc(input: TokenStream) -> TokenStream {
+pub fn vec(input: TokenStream) -> TokenStream {
     rules!(input.into() => {
         () => { quote! {
             Vec::new()

--- a/examples/macro_rules.rs
+++ b/examples/macro_rules.rs
@@ -10,12 +10,12 @@
 
 extern crate proc_macro;
 
-use quote::quote;
 use proc_macro::TokenStream;
 use proc_macro_rules::rules;
+use quote::quote;
 
 // Declarative version using macro_rules.
-macro_rules! vec {
+macro_rules! vec_rules {
     () => {
         Vec::new()
     };
@@ -32,7 +32,7 @@ macro_rules! vec {
 
 // Procedural version.
 #[proc_macro]
-pub fn vec(input: TokenStream) -> TokenStream {
+pub fn vec_proc(input: TokenStream) -> TokenStream {
     rules!(input.into() => {
         () => { quote! {
             Vec::new()
@@ -44,5 +44,6 @@ pub fn vec(input: TokenStream) -> TokenStream {
             )*
             temp_vec
         }}
-    }).into()
+    })
+    .into()
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro-rules-macros"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 repository = "https://github.com/nrc/proc-macro-rules"
@@ -12,6 +12,7 @@ license = "Apache-2.0/MIT"
 proc-macro = true
 
 [dependencies]
+proc-macro-hack = "0.5.20"
 quote = "1.0.26"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0.56"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0/MIT"
 proc-macro = true
 
 [dependencies]
-quote = "0.6.0"
-syn = { version = "0.15.0", features = ["full", "extra-traits"] }
-proc-macro2 = "0.4.21"
-proc-macro-hack = "0.5"
+quote = "1.0.26"
+syn = { version = "2.0.15", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0.56"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro-rules-macros"
-version = "0.3.0"
+version = "0.2.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 repository = "https://github.com/nrc/proc-macro-rules"
@@ -12,7 +12,6 @@ license = "Apache-2.0/MIT"
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.5.20"
 quote = "1.0.26"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0.56"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc-macro-rules-macros"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nick Cameron <nrc@ncameron.org>"]
 edition = "2018"
 repository = "https://github.com/nrc/proc-macro-rules"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0/MIT"
 proc-macro = true
 
 [dependencies]
+once_cell = "1.17.1"
 quote = "1.0.26"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 proc-macro2 = "1.0.56"

--- a/macros/src/ast.rs
+++ b/macros/src/ast.rs
@@ -1,6 +1,8 @@
 use crate::collect_vars;
 
-use proc_macro2::{Delimiter, Literal, Punct, Span, Ident};
+use once_cell::sync::OnceCell;
+use proc_macro2::{Delimiter, Ident, Literal, Punct, Span};
+use std::sync::Mutex;
 use syn::{Block, Expr};
 
 #[derive(Debug)]
@@ -110,13 +112,11 @@ impl SubRule {
     }
 }
 
-// FIXME(#10) WARNING: VERY THREAD-UNSAFE
 fn next_builder_name() -> String {
-    static mut NEXT_ID: u32 = 0;
-    unsafe {
-        NEXT_ID += 1;
-        format!("MatchesBuilder{}", NEXT_ID)
-    }
+    static NEXT_ID: OnceCell<Mutex<u32>> = OnceCell::with_value(Mutex::new(0));
+    let mut next_id = NEXT_ID.get().unwrap().lock().unwrap();
+    *next_id += 1;
+    format!("MatchesBuilder{}", next_id)
 }
 
 impl Fragment {

--- a/macros/src/ast.rs
+++ b/macros/src/ast.rs
@@ -1,7 +1,7 @@
 use crate::collect_vars;
 
-use proc_macro2::{Delimiter, Literal, Punct, Span};
-use syn::{Block, Expr, Ident};
+use proc_macro2::{Delimiter, Literal, Punct, Span, Ident};
+use syn::{Block, Expr};
 
 #[derive(Debug)]
 pub(crate) struct Rules {
@@ -93,7 +93,7 @@ pub(crate) enum FragmentBuilder {
 }
 
 impl SubRule {
-    pub(crate) fn to_builder(self, parent_name: Option<Ident>) -> RuleBuilder {
+    pub(crate) fn into_builder(self, parent_name: Option<Ident>) -> RuleBuilder {
         let mut variables = vec![];
         collect_vars(&self, &mut variables);
         let name = Ident::new(&next_builder_name(), Span::call_site());
@@ -101,7 +101,7 @@ impl SubRule {
             matchers: self
                 .matchers
                 .into_iter()
-                .map(|m| m.to_builder(Some(name.clone())))
+                .map(|m| m.into_builder(Some(name.clone())))
                 .collect(),
             variables,
             name,
@@ -120,14 +120,16 @@ fn next_builder_name() -> String {
 }
 
 impl Fragment {
-    pub(crate) fn to_builder(self, parent_name: Option<Ident>) -> FragmentBuilder {
+    pub(crate) fn into_builder(self, parent_name: Option<Ident>) -> FragmentBuilder {
         match self {
             Fragment::Var(i, t) => FragmentBuilder::Var(i, t),
-            Fragment::Repeat(r, rep, sep) => FragmentBuilder::Repeat(r.to_builder(parent_name), rep, sep),
+            Fragment::Repeat(r, rep, sep) => {
+                FragmentBuilder::Repeat(r.into_builder(parent_name), rep, sep)
+            }
             Fragment::Ident(i) => FragmentBuilder::Ident(i),
             Fragment::Punct(p) => FragmentBuilder::Punct(p),
             Fragment::Literal(l) => FragmentBuilder::Literal(l),
-            Fragment::Group(r, d) => FragmentBuilder::Group(r.to_builder(parent_name), d),
+            Fragment::Group(r, d) => FragmentBuilder::Group(r.into_builder(parent_name), d),
         }
     }
 }

--- a/macros/src/expand.rs
+++ b/macros/src/expand.rs
@@ -30,11 +30,11 @@ impl ToTokens for Rule {
 
         let rule = &self.lhs;
         let mut variables = vec![];
-        collect_vars(&rule, &mut variables);
-        let rule = rule.clone().to_builder(None);
+        collect_vars(rule, &mut variables);
+        let rule = rule.clone().into_builder(None);
         let vars = var_names(&variables);
         let builder_name = &rule.name;
-        let matches = matches(&builder_name, &variables);
+        let matches = matches(builder_name, &variables);
 
         tokens.append_all(quote!({
             #matches
@@ -395,6 +395,7 @@ impl ToTokens for FragmentBuilder {
                 tokens.append_all(quote! {
                     ms.expect(|ps, _| {
                         let i: proc_macro2::Ident = ps.parse()?;
+                        #[allow(clippy::cmp_owned)]
                         if i.to_string() == #i_str {
                             Ok(())
                         } else {
@@ -408,6 +409,7 @@ impl ToTokens for FragmentBuilder {
                 tokens.append_all(quote! {
                     ms.expect(|ps, _| {
                         let p: proc_macro2::Punct = ps.parse()?;
+                        #[allow(clippy::cmp_owned)]
                         if p.to_string() == #p_str {
                             Ok(())
                         } else {
@@ -421,6 +423,7 @@ impl ToTokens for FragmentBuilder {
                 tokens.append_all(quote! {
                     ms.expect(|ps, _| {
                         let l: proc_macro2::Literal = ps.parse()?;
+                        #[allow(clippy::cmp_owned)]
                         if l.to_string() == #l_str {
                             Ok(())
                         } else {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,7 +6,6 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
-use proc_macro_hack::proc_macro_hack;
 use quote::ToTokens;
 use syn::parse_macro_input;
 
@@ -14,7 +13,7 @@ mod ast;
 mod expand;
 mod parse;
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn rules(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as ast::Rules)
         .into_token_stream()

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,6 +6,7 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
+use proc_macro_hack::proc_macro_hack;
 use quote::ToTokens;
 use syn::parse_macro_input;
 
@@ -13,7 +14,7 @@ mod ast;
 mod expand;
 mod parse;
 
-#[proc_macro]
+#[proc_macro_hack]
 pub fn rules(input: TokenStream) -> TokenStream {
     parse_macro_input!(input as ast::Rules)
         .into_token_stream()

--- a/macros/src/parse.rs
+++ b/macros/src/parse.rs
@@ -4,14 +4,14 @@ use proc_macro2::TokenTree as TokenTree2;
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
 use syn::{
     braced, parenthesized, parse2,
-    token::{Brace, Comma, Dollar, FatArrow, Paren},
+    token::{Brace, Paren},
     Ident, Token,
 };
 
 impl Parse for Rules {
     fn parse(input: ParseStream) -> ParseResult<Rules> {
         let clause = input.parse()?;
-        input.parse::<FatArrow>()?;
+        input.parse::<Token![=>]>()?;
         let content;
         braced!(content in input);
         let mut rules = vec![];
@@ -29,7 +29,7 @@ impl Parse for Rule {
         parenthesized!(content in input);
         let lhs = content.parse()?;
 
-        input.parse::<FatArrow>()?;
+        input.parse::<Token![=>]>()?;
         let rhs = input.parse()?;
         Ok(Rule { lhs, rhs })
     }
@@ -41,7 +41,7 @@ impl Parse for Rhs {
             Ok(Rhs::Block(input.parse()?))
         } else {
             let e = input.parse()?;
-            input.parse::<Comma>()?;
+            input.parse::<Token![,]>()?;
             Ok(Rhs::Expr(e))
         }
     }
@@ -59,8 +59,8 @@ impl Parse for SubRule {
 
 impl Parse for Fragment {
     fn parse(input: ParseStream) -> ParseResult<Fragment> {
-        if input.peek(Dollar) {
-            let _: Dollar = input.parse()?;
+        if input.peek(Token![$]) {
+            let _: Token![$] = input.parse()?;
             if input.peek(Paren) {
                 let content;
                 parenthesized!(content in input);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,6 @@ extern crate proc_macro_rules_macros;
 pub extern crate syn;
 
 pub use crate::match_set::{Fork, MatchSet};
-use proc_macro_hack::proc_macro_hack;
-#[proc_macro_hack]
 pub use proc_macro_rules_macros::rules;
 
 mod match_set;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ extern crate proc_macro_rules_macros;
 pub extern crate syn;
 
 pub use crate::match_set::{Fork, MatchSet};
+use proc_macro_hack::proc_macro_hack;
+#[proc_macro_hack]
 pub use proc_macro_rules_macros::rules;
 
 mod match_set;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,15 +66,12 @@
 //! For example, in the first branch in the above example `ident` has type
 //! `syn::Ident` and `inner` has type `Vec<proc_macro2::TokenTree>`.
 
-
 extern crate proc_macro2;
-extern crate proc_macro_hack;
 extern crate proc_macro_rules_macros;
 #[doc(hidden)]
 pub extern crate syn;
 
 pub use crate::match_set::{Fork, MatchSet};
-#[proc_macro_hack::proc_macro_hack]
 pub use proc_macro_rules_macros::rules;
 
 mod match_set;
@@ -83,6 +80,7 @@ mod match_set;
 #[cfg(test)]
 mod tests {
     use crate as proc_macro_rules;
+    use super::*;
 
     #[test]
     fn test_smoke() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,6 @@
 //! For example, in the first branch in the above example `ident` has type
 //! `syn::Ident` and `inner` has type `Vec<proc_macro2::TokenTree>`.
 
-extern crate proc_macro2;
-extern crate proc_macro_rules_macros;
 #[doc(hidden)]
 pub extern crate syn;
 

--- a/src/match_set.rs
+++ b/src/match_set.rs
@@ -34,16 +34,14 @@ pub struct MatchHandler<'a, 'b: 'a, M: Fork> {
 
 impl<'a, M: Fork> MatchSet<'a, M> {
     pub fn new(initial: ParseBuffer<'a>) -> MatchSet<'a, M> {
-        let result = MatchSet {
+        MatchSet {
             positions: vec![Position {
                 input: initial,
                 matches: M::new(),
                 state: FragmentState::Ready,
             }],
             garbage: HashSet::new(),
-        };
-
-        result
+        }
     }
 
     pub fn finalise(self) -> syn::parse::Result<Vec<Position<'a, M>>> {
@@ -71,9 +69,8 @@ impl<'a, M: Fork> MatchSet<'a, M> {
                 outer_position: p,
                 forked: vec![],
             };
-            match f(forked_input, &mut match_handler) {
-                Ok(_) => forked.append(&mut match_handler.forked),
-                Err(_) => {}
+            if f(forked_input, &mut match_handler).is_ok() {
+                forked.append(&mut match_handler.forked);
             }
         }
 


### PR DESCRIPTION
I saw this crate (obligatory "nice crate BTW") and was saddened by the fact that it didn't work on newer rust versions. So.. I fixed it! :tada: This mostly involved updating dependencies to their newest versions but also fixed some other stuff (appeasing clippy, mostly)

Closes #10